### PR TITLE
Upgrade to support Gradle v9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,21 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url 'https://jitpack.io' }
+        maven { url 'https://groovy.jfrog.io/artifactory/libs-release/' }
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
+    maven { url 'https://groovy.jfrog.io/artifactory/libs-release/' }
 }
 
 apply plugin: 'groovy'
@@ -19,5 +25,10 @@ dependencies {
     implementation localGroovy()
     implementation gradleApi()
 
-    compileOnly "com.android.tools.build:gradle:3.0.1"
+    compileOnly "com.android.tools.build:gradle:8.0.2"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,13 +2,14 @@ buildscript {
     apply from: '../gradle/version.gradle'
     repositories {
         google()
+        mavenCentral()
+        gradlePluginPortal()
         maven {
             url uri("../${repo_name}")
         }
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "com.github.zellius:android-shortcut-gradle-plugin:${plugin_version}"
     }
 }

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Nov 26 21:02:47 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -9,6 +9,23 @@ def repository_url = "https://github.com/Zellius"
 
 def lib_description = 'Android Gradle plugin generates App Shortcuts shortcuts.xml for build flavors with different applicationId.'
 
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+tasks.register('groovydocJar', Jar) {
+    dependsOn groovydoc
+    archiveClassifier = 'groovydoc'
+    from groovydoc.destinationDir
+}
+
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
+    archiveClassifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 publishing {
     publications {
         PluginPublication(MavenPublication) {
@@ -69,37 +86,6 @@ bintray {
         version {
             name = project.version
             vcsTag = "v${project.version}"
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task groovydocJar(type: Jar, dependsOn: groovydoc) {
-    classifier 'groovydoc'
-    from groovydoc.destinationDir
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives groovydocJar
-    archives javadocJar
-}
-
-apply plugin: 'maven'
-
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: uri(repo_name))
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Oct 27 15:45:45 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/src/main/groovy/ru/solodovnikov/shortcuthelper/PrepareShortcutTask.groovy
+++ b/src/main/groovy/ru/solodovnikov/shortcuthelper/PrepareShortcutTask.groovy
@@ -1,5 +1,6 @@
 package ru.solodovnikov.shortcuthelper
 
+import groovy.xml.XmlSlurper
 import groovy.xml.XmlUtil
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input


### PR DESCRIPTION
- Upgrade Gradle to version 8.5 and the Android Gradle Plugin to 8.0.2.
- Replacing deprecated configurations and setting Java compatibility to version 17.
- Add necessary imports for XML processing in the `PrepareShortcutTask.groovy`.